### PR TITLE
Incorporate MT's design

### DIFF
--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -330,7 +330,7 @@ Both endpoints MUST parse their peer's Version Information during the
 handshake. If the Version Information was missing or if parsing it failed (for
 example, if it is too short or if its length is not divisible by four), then
 the endpoint MUST close the connection; if the connection was using QUIC
-version 1, it MUST be closed with a transport error of type
+version 1, that connection closure MUST use a transport error of type
 `TRANSPORT_PARAMETER_ERROR`.
 
 If a client has reacted to a Version Negotiation packet, it MUST validate that
@@ -339,7 +339,7 @@ version, and that the client would have selected the same negotiated version if
 it had received a Version Negotiation packet whose Supported Versions field had
 the same contents as the server's `Other Versions` field. If any of these
 checks fail, the client MUST close the connection; if the connection was using
-QUIC version 1, it MUST be closed with a transport error of type
+QUIC version 1, that connection closure MUST use a transport error of type
 `VERSION_NEGOTIATION_ERROR`. This prevents an attacker from being able to use
 forged Version Negotiation packets to force a version downgrade.
 

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -340,8 +340,9 @@ it had received a Version Negotiation packet whose Supported Versions field had
 the same contents as the server's `Other Versions` field. If any of these
 checks fail, the client MUST close the connection; if the connection was using
 QUIC version 1, that connection closure MUST use a transport error of type
-`VERSION_NEGOTIATION_ERROR`. This prevents an attacker from being able to use
-forged Version Negotiation packets to force a version downgrade.
+`VERSION_NEGOTIATION_ERROR`. This connection closure prevents an attacker from
+being able to use forged Version Negotiation packets to force a version
+downgrade.
 
 After the process of version negotiation in this document completes, the
 version in use for the connection is the version that the server sent in the

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -311,7 +311,7 @@ instead.
 Server-Sent Other Versions:
 
 : When sent by a server, the `Other Versions` field lists all the
-Fully-Supported Versions of this server deployment, see {{server-fleet}}.
+Fully-Deployed Versions of this server deployment, see {{server-fleet}}.
 
 Clients and servers MAY both include versions following the pattern
 `0x?a?a?a?a` in their `Other Versions` list. Those versions are reserved to

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -182,9 +182,9 @@ the versions are compatible.
 The client initiates a QUIC connection by sending a first flight of QUIC
 packets with a long header to the server {{INV}}. We'll refer to the version of
 those packets as the "original version". The client's first flight includes
-handshake version information (see {{hs-vers-info}}) which will be used to
-optionally enable compatible version negotation (see {{compat-vn}}), and to
-prevent version downgrade attacks (see {{downgrade}}).
+Version Information (see {{vers-info}}) which will be used to optionally enable
+compatible version negotation (see {{compat-vn}}), and to prevent version
+downgrade attacks (see {{downgrade}}).
 
 Upon receiving this first flight, the server verifies whether it knows how to
 parse first flights from the original version. If it does not, then it starts
@@ -226,17 +226,17 @@ sends a new first flight with that version - we refer to this version as the
 
 The new first flight will allow the endpoints to establish a connection using
 the negotiated version. The handshake of the negotiated version will exchange
-handshake version information (see {{hs-vers-info}}) required to ensure that VN
-was genuine, i.e. that no attacker injected packets in order to influence the
-VN process, see {{downgrade}}.
+Version Information (see {{vers-info}}) required to ensure that VN was genuine,
+i.e. that no attacker injected packets in order to influence the VN process,
+see {{downgrade}}.
 
 
 ## Compatible Version Negotiation {#compat-vn}
 
 When the server can parse the client's first flight using the original version,
-it can extract the client's handshake version information (see
-{{hs-vers-info}}). This contains the list of versions that the client thinks
-its first flight is compatible with.
+it can extract the client's Version Information (see {{vers-info}}). This
+contains the list of versions that the client thinks its first flight is
+compatible with.
 
 If the server supports one of the client's compatible versions, and the server
 also believes that the original version is compatible with this version, then
@@ -261,22 +261,21 @@ balancers to ensure that packets for a given connection are routed to the same
 server.
 
 
-# Handshake Version Information {#hs-vers-info}
+# Version Information {#vers-info}
 
-During the handshake, endpoints will exchange handshake version information,
-which is a blob of data that is defined below. In QUIC version 1, the handshake
-version information is transmitted using a new transport parameter,
-`version_negotiation`. The contents of handshake version information are shown
-below (using the notation from the "Notational Conventions" section of
-{{QUIC}}):
+During the handshake, endpoints will exchange Version Information, which is a
+blob of data that is defined below. In QUIC version 1, the Version Information
+is transmitted using a new transport parameter, `version_information`. The
+contents of Version Information are shown below (using the notation from the
+"Notational Conventions" section of {{QUIC}}):
 
 ~~~
-Handshake Version Information {
+Version Information {
   Chosen Version (32),
   Other Versions (32) ...,
 }
 ~~~
-{: #fig-hvi-format title="Handshake Version Information Format"}
+{: #fig-vi-format title="Version Information Format"}
 
 The content of each field is described below:
 
@@ -316,11 +315,11 @@ version that they initially attempted. Once a client has reacted to a Version
 Negotiation packet, it MUST drop all subsequent Version Negotiation packets on
 that connection.
 
-Both endpoints MUST parse their peer's Handshake Version Information during the
-handshake. If the Handshake Version Information was missing or if parsing it
-failed (for example, if it is too short or if its length is not divisible by
-four), then the endpoint MUST close the connection. If the connection was using
-QUIC version 1, it MUST be closed with a transport error of type
+Both endpoints MUST parse their peer's Version Information during the
+handshake. If the Version Information was missing or if parsing it failed (for
+example, if it is too short or if its length is not divisible by four), then
+the endpoint MUST close the connection. If the connection was using QUIC
+version 1, it MUST be closed with a transport error of type
 `TRANSPORT_PARAMETER_ERROR`.
 
 If a client has reacted to a Version Negotiation packet, it MUST validate that
@@ -335,11 +334,11 @@ forged Version Negotiation packets to force a version downgrade.
 
 After the process of version negotiation in this document completes, the
 version in use for the connection is the version that the server sent in the
-`Chosen Version` field of its Handshake Version Information. That remains true
-even if other versions were used in the Version field of long headers at any
-point in the lifetime of the connection; endpoints MUST NOT change the version
-that they consider to be in use based on the Version field of long headers as
-that field could be forged by attackers.
+`Chosen Version` field of its Version Information. That remains true even if
+other versions were used in the Version field of long headers at any point in
+the lifetime of the connection; endpoints MUST NOT change the version that they
+consider to be in use based on the Version field of long headers as that field
+could be forged by attackers.
 
 
 # Client Choice of Original Version
@@ -355,14 +354,14 @@ QUIC version 1 features retry packets, which the server can send to validate
 the client's IP address before parsing the client's first flight. This impacts
 compatible version negotiation because a server who wishes to send a retry
 packet before parsing the client's first flight won't have parsed the client's
-handshake version information yet. If a future document wishes to define
-compatibility between two versions that support retry, that document MUST
-specify how version negotiation (both compatible and incompatible) interacts
-with retry during a handshake that requires both. For example, that could be
-accomplished by having the server send a retry packet first and validating the
-client's IP address before starting version negotiation and deciding whether to
-use compatible version negotiation on that connection (in that scenario the
-retry packet would be sent using the original version).
+Version Information yet. If a future document wishes to define compatibility
+between two versions that support retry, that document MUST specify how version
+negotiation (both compatible and incompatible) interacts with retry during a
+handshake that requires both. For example, that could be accomplished by having
+the server send a retry packet first and validating the client's IP address
+before starting version negotiation and deciding whether to use compatible
+version negotiation on that connection (in that scenario the retry packet would
+be sent using the original version).
 
 
 # Interaction with 0-RTT
@@ -393,7 +392,7 @@ should avoid introducing new frames in initial packets.
 # Security Considerations
 
 The security of this version negotiation mechanism relies on the authenticity
-of the handshake version information exchanged during the handshake. In QUIC
+of the Version Information exchanged during the handshake. In QUIC
 version 1, transport parameters are authenticated ensuring the security of this
 mechanism. Negotiation between compatible versions will have the security of
 the weakest common version.
@@ -413,7 +412,7 @@ Transport Parameter Registry:
   +----------+---------------------+---------------+
   | Value    |   Parameter Name    |   Reference   |
   +----------+---------------------+---------------+
-  | 0xFF73DB | version_negotiation | This document |
+  | 0xFF73DB | version_information | This document |
   +----------+---------------------+---------------+
 ~~~
 

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -76,7 +76,7 @@ therefore define the following terms:
 
 Supported Versions:
 
-: This is the set of versions supported by a given individual server.
+: This is the set of versions supported by a given individual server instance.
 
 Fully-Deployed Versions:
 
@@ -276,11 +276,11 @@ a transport error of type `VERSION_NEGOTIATION_ERROR`.
 
 If a client has reacted to a Version Negotiation packet, it MUST parse the
 server's `Other Versions` field and validate that it does not contain the
-client's original version. If this validation fails, the server MUST close the
+client's original version. If this validation fails, the client MUST close the
 connection. If the connection was using QUIC version 1, it MUST be closed with
-a transport error of type `VERSION_NEGOTIATION_ERROR`. This mitigates an
-attacker's ability to forge Version Negotiation packets to force a version
-downgrade.
+a transport error of type `VERSION_NEGOTIATION_ERROR`. This prevents 
+an attacker from being able to use forged Version Negotiation packets to
+force a version downgrade.
 
 If an endpoint receives its peer's Handshake Version Information and fails to
 parse it (for example, if it is too short or if its length is not divisible by
@@ -389,4 +389,3 @@ Transport Error Codes Registry:
 
 The authors would like to thank Martin Thomson, Mike Bishop, Nick Banks, Ryan
 Hamilton, and Roberto Peon for their input and contributions.
-

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -94,11 +94,11 @@ single QUIC server instance in this deployment. If a deployment only contains a
 single server instance, then this set is equal to the Negotiated Versions set,
 except during short transitions while versions are added or removed (see below).
 
-If a deployment contains multiple server instances, it is possible for software
-updates to not happen at the exact same time on all server instances. Because
-of this, a client might receive a Version Negotiation packet from a server
-instance that has already been updated and the client's resulting connection
-attempt might reach a different server instance which hasn't been updated yet.
+If a deployment contains multiple server instances, software updates may not
+happen at exactly the same time on all server instances. Because of this, a
+client might receive a Version Negotiation packet from a server instance that
+has already been updated and the client's resulting connection attempt might
+reach a different server instance which hasn't been updated yet.
 
 However, even when there is only a single server instance, it is still possible
 to receive a stale Version Negotiation packet if the server performs its
@@ -109,25 +109,34 @@ This could cause the version downgrade prevention mechanism described in
 operators SHOULD perform a three-step process when they wish to add or remove
 support for a version:
 
-* When adding support for a new version, the first step is to progressively add
-  support for the new version to all server instances. This step updates the
-  Accepted Versions but not the Negotiated Versions nor the Fully-Deployed
-  Versions. Once all server instances have been updated, operators wait for at
-  least one minute to allow any in-flight Version Negotiation packets to
-  arrive. Then, the second step is to progressively add the new version to
-  Negotiated Versions on all server instances. Once complete, operators wait
-  for at least another minute. Finally, the third step is to progressively add
-  the new version to Fully-Deployed Versions on all server instances.
+When adding support for a new version:
 
-* When removing support for a version, the first step is to progressively
-  remove the version from Fully-Deployed Versions on all server instances. Once
-  it has been removed on all server instances, operators wait for at least one
-  minute to allow any in-flight Version Negotiation packets to arrive. Then,
-  the second step is to progressively remove the version from Negotiated
+* The first step is to progressively add support for the new version to all
+  server instances. This step updates the Accepted Versions but not the
+  Negotiated Versions nor the Fully-Deployed Versions. Once all server
+  instances have been updated, operators wait for at least one minute to allow
+  any in-flight Version Negotiation packets to arrive.
+
+* Then, the second step is to progressively add the new version to Negotiated
   Versions on all server instances. Once complete, operators wait for at least
-  another minute. Finally, the third step is to progressively remove support for
-  the version from all server instances. That step updates the Supported
-  Versions.
+  another minute.
+
+* Finally, the third step is to progressively add the new version to
+  Fully-Deployed Versions on all server instances.
+
+When removing support for a version:
+
+* The first step is to progressively remove the version from Fully-Deployed
+  Versions on all server instances. Once it has been removed on all server
+  instances, operators wait for at least one minute to allow any in-flight
+  Version Negotiation packets to arrive.
+
+* Then, the second step is to progressively remove the version from Negotiated
+  Versions on all server instances. Once complete, operators wait for at least
+  another minute.
+
+* Finally, the third step is to progressively remove support for the version
+  from all server instances. That step updates the Supported Versions.
 
 
 Note that this opens connections to version downgrades (but only for
@@ -211,10 +220,10 @@ the Version Negotiation packet, and a distinct connection after.
 ## Incompatible Version Negotiation {#incompat-vn}
 
 The server starts incompatible version negotiation by sending a Version
-Negotiation packet. This packet SHALL list the server's set of Negotiated
-Versions (see {{server-fleet}}) in the packet's Supported Version field. The
+Negotiation packet. This packet SHALL include each entry from the server's set
+of Negotiated Versions (see {{server-fleet}}) in a Supported Version field. The
 server MAY add reserved versions (as defined in the Versions section of
-{{QUIC}}) to the Supported Version field.
+{{QUIC}}) in Supported Version fields.
 
 Upon receiving the VN packet, the client will search for a version it supports
 in the list provided by the server. If it doesn't find one, it aborts the
@@ -224,7 +233,7 @@ sends a new first flight with that version - we refer to this version as the
 
 The new first flight will allow the endpoints to establish a connection using
 the negotiated version. The handshake of the negotiated version will exchange
-Version Information (see {{vers-info}}) required to ensure that VN was genuine,
+version information (see {{vers-info}}) required to ensure that VN was genuine,
 i.e. that no attacker injected packets in order to influence the VN process,
 see {{downgrade}}.
 
@@ -232,8 +241,8 @@ see {{downgrade}}.
 ## Compatible Version Negotiation {#compat-vn}
 
 When the server can parse the client's first flight using the original version,
-it can extract the client's Version Information (see {{vers-info}}). This
-contains the list of versions that the client thinks its first flight is
+it can extract the client's Version Information structure (see {{vers-info}}).
+This contains the list of versions that the client thinks its first flight is
 compatible with.
 
 If the server supports one of the client's compatible versions, and the server


### PR DESCRIPTION
This PR simplifies the document's design. The new simplified design was by @martinthomson . It removes the indication of server versions that everyone seemed to think was useless, but apart from that has very similar properties to the previous design. One important difference is that it is now the client's responsibility to detect VN-packet-based downgrade attacks instead of the server's.

[An HTML version of what the draft would look like with this PR merged is available here](https://quicwg.org/version-negotiation/simplify/draft-ietf-quic-version-negotiation.html).