### PR TITLE
Remove redundant attribute

### DIFF
--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -7,7 +7,6 @@ wg: QUIC
 
 ipr: trust200902
 area: General
-workgroup: QUIC Working Group
 keyword: Internet-Draft
 
 stand_alone: yes


### PR DESCRIPTION
kramdown supports both, but having both just causes warnings