### PR TITLE
Client validation

### DIFF
--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -28,6 +28,9 @@ author:
     organization: Mozilla
     email: ekr@rtfm.com
 
+normative:
+  RFC8999:
+
 
 --- abstract
 

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -229,12 +229,12 @@ that follows.
 The server starts incompatible version negotiation by sending a Version
 Negotiation packet. This packet SHALL include each entry from the server's set
 of Offered Versions (see {{server-fleet}}) in a Supported Version field. The
-server MAY add reserved versions (as defined in the Versions section of
-{{QUIC}}) in Supported Version fields.
+server MAY add reserved versions (as defined in {{Section 6.3 of QUIC}}) in
+Supported Version fields.
 
 A client MUST ignore a Version Negotiation packet if it contains the original
 version attempted by the client.  The client also ignores a Version Negotiation
-that contains incorrect connection ID fields.
+that contains incorrect connection ID fields; see {{Section 6 of RFC8999}}.
 
 Upon receiving the VN packet, the client will search for a version it supports
 in the list provided by the server. If it doesn't find one, it aborts the

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -235,7 +235,7 @@ of Offered Versions (see {{server-fleet}}) in a Supported Version field. The
 server MAY add reserved versions (as defined in {{Section 6.3 of QUIC}}) in
 Supported Version fields.
 
-A client MUST ignore a Version Negotiation packet if it contains the original
+Clients will ignore a Version Negotiation packet if it contains the original
 version attempted by the client.  The client also ignores a Version Negotiation
 that contains incorrect connection ID fields; see {{Section 6 of RFC8999}}.
 
@@ -352,7 +352,7 @@ transport error of type `VERSION_NEGOTIATION_ERROR`.
 The client MUST validate the server `Other Versions` field by confirming that it
 would have attempted the same version with this knowledge of the versions the
 server supports. That is, the client would have selected the same version if it
-received Version Negotiation packet that listed the versions in the server's
+received a Version Negotiation packet that listed the versions in the server's
 `Other Versions` field, plus the negotiated version. If the client would have
 selected a different version, the client MUST close the connection; if the
 connection was using QUIC version 1, that connection closure MUST use a

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -349,8 +349,8 @@ the Version Information was missing, the client MUST close the connection; if
 the connection was using QUIC version 1, that connection closure MUST use a
 transport error of type `VERSION_NEGOTIATION_ERROR`.
 
-If the client received and acted on a Version Negotiation packet, it client MUST
-validate the server `Other Versions` field.  The `Other Versions` field is
+If the client received and acted on a Version Negotiation packet, the client MUST
+validate the server's `Other Versions` field.  The `Other Versions` field is
 validated by confirming that the client would have attempted the same version
 with knowledge of the versions the server supports. That is, the client would
 have selected the same version if it received a Version Negotiation packet that

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -232,6 +232,10 @@ of Offered Versions (see {{server-fleet}}) in a Supported Version field. The
 server MAY add reserved versions (as defined in the Versions section of
 {{QUIC}}) in Supported Version fields.
 
+A client MUST ignore a Version Negotiation packet if it contains the original
+version attempted by the client.  The client also ignores a Version Negotiation
+that contains incorrect connection ID fields.
+
 Upon receiving the VN packet, the client will search for a version it supports
 in the list provided by the server. If it doesn't find one, it aborts the
 connection attempt. Otherwise, it selects a mutually supported version and
@@ -342,16 +346,20 @@ the Version Information was missing, the client MUST close the connection; if
 the connection was using QUIC version 1, that connection closure MUST use a
 transport error of type `VERSION_NEGOTIATION_ERROR`.
 
-If a client has reacted to a Version Negotiation packet, it MUST validate that
-the server's `Other Versions` field does not contain the client's original
-version, and that the client would have selected the same negotiated version if
-it had received a Version Negotiation packet whose Supported Versions field had
-the same contents as the server's `Other Versions` field. If any of these
-checks fail, the client MUST close the connection; if the connection was using
-QUIC version 1, that connection closure MUST use a transport error of type
-`VERSION_NEGOTIATION_ERROR`. This connection closure prevents an attacker from
-being able to use forged Version Negotiation packets to force a version
-downgrade.
+The client MUST validate the server `Other Versions` field by confirming that it
+would have attempted the same version with this knowledge of the versions the
+server supports. That is, the client would have selected the same version if it
+received Version Negotiation packet that listed the versions in the server's
+`Other Versions` field, plus the negotiated version. If the client would have
+selected a different version, the client MUST close the connection; if the
+connection was using QUIC version 1, that connection closure MUST use a
+transport error of type `VERSION_NEGOTIATION_ERROR`. This connection closure
+prevents an attacker from being able to use forged Version Negotiation packets
+to force a version downgrade.
+
+This validation of `Other Versions` is not sufficient to prevent downgrade.
+Downgrade prevention also depends on the client ignoring Version Negotiation
+packets that contain the original version; see {{incompat-vn}}.
 
 After the process of version negotiation in this document completes, the
 version in use for the connection is the version that the server sent in the

--- a/draft-ietf-quic-version-negotiation.md
+++ b/draft-ietf-quic-version-negotiation.md
@@ -349,16 +349,18 @@ the Version Information was missing, the client MUST close the connection; if
 the connection was using QUIC version 1, that connection closure MUST use a
 transport error of type `VERSION_NEGOTIATION_ERROR`.
 
-The client MUST validate the server `Other Versions` field by confirming that it
-would have attempted the same version with this knowledge of the versions the
-server supports. That is, the client would have selected the same version if it
-received a Version Negotiation packet that listed the versions in the server's
-`Other Versions` field, plus the negotiated version. If the client would have
-selected a different version, the client MUST close the connection; if the
-connection was using QUIC version 1, that connection closure MUST use a
-transport error of type `VERSION_NEGOTIATION_ERROR`. This connection closure
-prevents an attacker from being able to use forged Version Negotiation packets
-to force a version downgrade.
+If the client received and acted on a Version Negotiation packet, it client MUST
+validate the server `Other Versions` field.  The `Other Versions` field is
+validated by confirming that the client would have attempted the same version
+with knowledge of the versions the server supports. That is, the client would
+have selected the same version if it received a Version Negotiation packet that
+listed the versions in the server's `Other Versions` field, plus the negotiated
+version. If the client would have selected a different version, the client MUST
+close the connection; if the connection was using QUIC version 1, that
+connection closure MUST use a transport error of type
+`VERSION_NEGOTIATION_ERROR`. This connection closure prevents an attacker from
+being able to use forged Version Negotiation packets to force a version
+downgrade.
 
 This validation of `Other Versions` is not sufficient to prevent downgrade.
 Downgrade prevention also depends on the client ignoring Version Negotiation
@@ -468,5 +470,5 @@ Transport Error Codes Registry:
 # Acknowledgments {#acknowledgments}
 {:numbered="false"}
 
-The authors would like to thank Martin Thomson, Mike Bishop, Nick Banks, Ryan
-Hamilton, and Roberto Peon for their input and contributions.
+The authors would like to thank Nick Banks, Mike Bishop, Ryan Hamilton, Roberto
+Peon, Anthony Rossi, and Martin Thomson for their input and contributions.


### PR DESCRIPTION


In light of discussion in slack, the problem here is that the validation
is based on the *negotiated* version.  Validation needs to be based on
the client's *selected* version.

I've also moved text about validating lack of support for the original
version to the incompatible VN section, alongside a reminder to validate
connection IDs.  Security does depend on this, but the client ignores
these bad VN packets.  That provides more effective defense against
attack than what was here originally.